### PR TITLE
Match v0238

### DIFF
--- a/openpivgui/MultiProcessing.py
+++ b/openpivgui/MultiProcessing.py
@@ -224,7 +224,7 @@ class MultiProcessing(piv_tls.Multiprocesser):
             correlation_method=self.parameter['corr_method'],
             normalized_correlation=self.parameter['normalize_correlation'])
 
-        x, y = piv_wdf.get_coordinates(frame_a.shape,
+        x, y = piv_wdf.get_rect_coordinates(frame_a.shape,
                                        corr_window_0,
                                        overlap_0)
 

--- a/openpivgui/MultiProcessing.py
+++ b/openpivgui/MultiProcessing.py
@@ -225,8 +225,8 @@ class MultiProcessing(piv_tls.Multiprocesser):
             normalized_correlation=self.parameter['normalize_correlation'])
 
         x, y = piv_wdf.get_rect_coordinates(frame_a.shape,
-                                       corr_window_0,
-                                       overlap_0)
+                                            corr_window_0,
+                                            overlap_0)
 
         # validating first pass
         mask = np.full_like(x, 0)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="openpivgui",
     version="0.4.11",
-    install_requires=['OpenPiv', 'pandas'],
+    install_requires=['OpenPiv==0.23.8', 'pandas'],
     author="P. Vennemann and contributors.",
     author_email="vennemann@fh-muenster.de",
     description="A simple GUI for Open PIV.",


### PR DESCRIPTION
openpiv-python v 0.23.8 implemented rectangular windows and now it's called `get_rect_coordinates`