### PR TITLE
change deprecated np.float to float

### DIFF
--- a/openpivgui/OpenPivGui.py
+++ b/openpivgui/OpenPivGui.py
@@ -598,7 +598,7 @@ class OpenPivGui(tk.Tk):
             self.get_settings()
 
             data = self.load_pandas(self.p['fnames'][self.index])
-            data = data.to_numpy().astype(np.float)
+            data = data.to_numpy().astype(float)
 
             try:
                 invalid = data[:, 4].astype('bool')

--- a/openpivgui/vec_plot.py
+++ b/openpivgui/vec_plot.py
@@ -219,7 +219,7 @@ def vector(data, parameter, figure, invert_yaxis=True, valid_color='blue',
         figure : matplotlib.figure.Figure
             An (empty) Figure object.
     """
-    data = data.to_numpy().astype(np.float)
+    data = data.to_numpy().astype(float)
 
     try:
         invalid = data[:, 4].astype('bool')
@@ -411,7 +411,7 @@ def contour_and_vector(data, parameter, figure, **kw):
                       extend=extend)
 
     # quiver plot
-    data = data.to_numpy().astype(np.float)
+    data = data.to_numpy().astype(float)
 
     try:
         invalid = data[:, 4].astype('bool')


### PR DESCRIPTION
This tiny PR fixes the deprecated/removed `np.float` and replaces it with `float`. With this change (and the fix in OpenPIV/openpiv-python#292) I was able to get the GUI working.

I didn't make any changes under `build/lib`, just within `openpivgui` at the root of the repo; not sure if those need to be changed as well.